### PR TITLE
chore: bump up nitro 0.29.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,11 @@
         "@types/jest": "^29.5.12",
         "@types/react": "19.1.0",
         "conventional-changelog-conventionalcommits": "^9.1.0",
-        "nitrogen": "^0.29.6",
+        "nitrogen": "^0.29.8",
         "react": "19.1.0",
         "react-native": "0.81.4",
         "react-native-builder-bob": "^0.37.0",
-        "react-native-nitro-modules": "^0.29.6",
+        "react-native-nitro-modules": "^0.29.8",
         "semantic-release": "^24.2.8",
         "typescript": "^5.8.3",
       },
@@ -30,7 +30,7 @@
       "dependencies": {
         "react": "19.1.0",
         "react-native": "0.81.4",
-        "react-native-nitro-modules": "^0.29.6",
+        "react-native-nitro-modules": "^0.29.8",
         "react-native-safe-area-context": "^5.5.2",
       },
       "devDependencies": {
@@ -344,6 +344,10 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+
     "@isaacs/ttlcache": ["@isaacs/ttlcache@1.4.1", "", {}, "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA=="],
 
     "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
@@ -500,7 +504,7 @@
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
 
-    "@ts-morph/common": ["@ts-morph/common@0.26.1", "", { "dependencies": { "fast-glob": "^3.3.2", "minimatch": "^9.0.4", "path-browserify": "^1.0.1" } }, "sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA=="],
+    "@ts-morph/common": ["@ts-morph/common@0.28.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-4w6X/oFmvXcwux6y6ExfM/xSqMHw20cYwFJH+BlYrtGa6nwY9qGq8GXnUs1sVYeF2o/KT3S8hAH6sKBI3VOkBg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -690,7 +694,7 @@
 
     "chromium-edge-launcher": ["chromium-edge-launcher@0.2.0", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0", "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg=="],
 
-    "ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+    "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
@@ -872,7 +876,7 @@
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
-    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+    "eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
 
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
@@ -911,6 +915,8 @@
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -1324,7 +1330,7 @@
 
     "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
 
-    "nitrogen": ["nitrogen@0.29.6", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.29.6", "ts-morph": "^25.0.0", "yargs": "^17.7.2", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-LwHgCvxx3ruMM7Pv7j/aKhM7yL2yDtasRxH2yprAcZYTYqyRS6SFsjr2PJXAqFJtqtta/2OEghHRdHeZBW6b5A=="],
+    "nitrogen": ["nitrogen@0.29.8", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.29.8", "ts-morph": "^27.0.0", "yargs": "^17.7.2", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-ISqyNlqKb06APsSaPQSkbfekQwM7FuoBr3V4Ac9ktq13Vv5s6cg++efkfyEB1lGSBKtd/ceJox/2GWL/TI5Zhw=="],
 
     "nocache": ["nocache@3.0.4", "", {}, "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw=="],
 
@@ -1482,7 +1488,7 @@
 
     "react-native-builder-bob": ["react-native-builder-bob@0.37.0", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-transform-strict-mode": "^7.24.7", "@babel/preset-env": "^7.25.2", "@babel/preset-flow": "^7.24.7", "@babel/preset-react": "^7.24.7", "@babel/preset-typescript": "^7.24.7", "babel-plugin-module-resolver": "^5.0.2", "browserslist": "^4.20.4", "cosmiconfig": "^9.0.0", "cross-spawn": "^7.0.3", "dedent": "^0.7.0", "del": "^6.1.1", "escape-string-regexp": "^4.0.0", "fs-extra": "^10.1.0", "glob": "^8.0.3", "is-git-dirty": "^2.0.1", "json5": "^2.2.1", "kleur": "^4.1.4", "metro-config": "^0.80.9", "prompts": "^2.4.2", "which": "^2.0.2", "yargs": "^17.5.1" }, "bin": { "bob": "bin/bob" } }, "sha512-CkM4csFrYtdGJoRLbPY6V8LBbOxgPZIuM0MkPaiOI2F/ASwxMAzoJu9wBw8Pyvx1p27XnrIEKPyDiTqimJ7xbA=="],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.29.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Zm7x7DPx2bYc/eMfJ4lg2CCyXRCEm6as1ZyVU/2vCqMskiQxQquL3INqjne+tEJw+/h+mrnKrb7z7PiUitzEQw=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.29.8", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-SyKIR+MmAZadqFEPwD+wiHoG5Lem3EMtAyzLOJ+mU0JB+1+vHxxLLhcV0THoXoxbMSbf5zWOQYVb+JPCEhNtXg=="],
 
     "react-native-nitro-text-example": ["react-native-nitro-text-example@workspace:example"],
 
@@ -1676,6 +1682,8 @@
 
     "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
 
+    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -1686,7 +1694,7 @@
 
     "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
 
-    "ts-morph": ["ts-morph@25.0.1", "", { "dependencies": { "@ts-morph/common": "~0.26.0", "code-block-writer": "^13.0.3" } }, "sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ=="],
+    "ts-morph": ["ts-morph@27.0.0", "", { "dependencies": { "@ts-morph/common": "~0.28.0", "code-block-writer": "^13.0.3" } }, "sha512-xcqelpTR5PCuZMs54qp9DE3t7tPgA2v/P1/qdW4ke5b3Y5liTGTYj6a/twT35EQW/H5okRqp1UOqwNlgg0K0eQ=="],
 
     "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -1808,8 +1816,6 @@
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
-
     "@babel/eslint-parser/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1888,7 +1894,7 @@
 
     "@semantic-release/release-notes-generator/get-stream": ["get-stream@7.0.1", "", {}, "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ=="],
 
-    "@ts-morph/common/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "@ts-morph/common/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -1928,6 +1934,8 @@
 
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
     "eslint-plugin-eslint-comments/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "eslint-plugin-jest/@typescript-eslint/utils": ["@typescript-eslint/utils@5.62.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@types/json-schema": "^7.0.9", "@types/semver": "^7.3.12", "@typescript-eslint/scope-manager": "5.62.0", "@typescript-eslint/types": "5.62.0", "@typescript-eslint/typescript-estree": "5.62.0", "eslint-scope": "^5.1.1", "semver": "^7.3.7" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ=="],
@@ -1936,7 +1944,11 @@
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -1964,8 +1976,6 @@
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
-
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -1983,6 +1993,8 @@
     "marked-terminal/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
 
@@ -2432,6 +2444,8 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
+    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -2505,8 +2519,6 @@
     "@semantic-release/npm/execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@semantic-release/npm/execa/strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
-
-    "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -2595,6 +2607,8 @@
     "metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
     "metro-config/metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "metro-config/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "metro-config/metro/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,14 @@
-import React, { useLayoutEffect, useState } from 'react';
-import { Platform, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
+import React, { useLayoutEffect, useMemo, useState } from 'react';
+import {
+    Platform,
+    ScrollView,
+    StatusBar,
+    StyleProp,
+    StyleSheet,
+    Text,
+    TextStyle,
+    View,
+} from 'react-native';
 import { NitroText, TextLayoutEvent } from 'react-native-nitro-text';
 
 const htmlComingFromServer = `
@@ -165,6 +174,38 @@ export default function App() {
     // setLayoutInfo(`Lines: ${lines.length}`);
   };
 
+  const htmlStyles: Record<string, StyleProp<TextStyle>> = useMemo(
+    () => ({
+      b: { fontWeight: 'bold', color: '#E53E3E' }, // deep red
+      i: { fontStyle: 'italic', color: '#3182CE' }, // bright blue
+      u: { textDecorationStyle: 'dashed', textDecorationColor: '#38A169' }, // green
+      s: { textDecorationStyle: 'dashed', textDecorationColor: '#E53E3E' }, // red
+      code: {
+        fontFamily: Platform.select({
+          android: 'monospace',
+          ios: 'ui-monospace',
+        }),
+        color: '#805AD5',
+      }, // purple
+      pre: {
+        fontFamily: Platform.select({
+          android: 'monospace',
+          ios: 'ui-monospace',
+        }),
+        color: '#805AD5',
+      }, // purple
+      p: { color: '#2D3748' }, // dark gray for better readability
+      a: { color: 'green' }, // lighter blue for links
+      h1: { color: '#2F855A', fontWeight: 'bold', fontSize: 32 }, // darker green
+      h2: { color: '#2C5282', fontWeight: 'bold', fontSize: 24 }, // darker blue
+      h3: { color: '#C05621', fontWeight: 'bold', fontSize: 18.72 }, // darker orange
+      h4: { color: '#553C9A', fontWeight: 'bold', fontSize: 16 }, // darker purple
+      h5: { color: '#744210', fontWeight: 'bold', fontSize: 13.28 }, // darker brown
+      h6: { color: '#4A5568', fontWeight: 'bold', fontSize: 10.72 }, // medium gray
+    }),
+    [],
+  );
+
   useLayoutEffect(() => {
     StatusBar.setBarStyle('dark-content');
   }, []);
@@ -217,22 +258,7 @@ export default function App() {
           selectable
           style={styles.htmlText}
           renderer="html"
-          renderStyles={{
-            b: { fontWeight: 'bold', color: '#E53E3E' }, // deep red
-            i: { fontStyle: 'italic', color: '#3182CE' }, // bright blue
-            u: { textDecorationStyle: 'dashed', textDecorationColor: '#38A169' }, // green
-            s: { textDecorationStyle: 'dashed', textDecorationColor: '#E53E3E' }, // red
-            code: { fontFamily: Platform.select({android:'monospace', ios: "ui-monospace"}), color: '#805AD5' }, // purple
-            pre: { fontFamily: Platform.select({android:'monospace', ios: "ui-monospace"}), color: '#805AD5' }, // purple
-            p: { color: '#2D3748' }, // dark gray for better readability
-            a: { color: 'green' }, // lighter blue for links
-            h1: { color: '#2F855A', fontWeight: 'bold', fontSize: 32 }, // darker green
-            h2: { color: '#2C5282', fontWeight: 'bold', fontSize: 24 }, // darker blue
-            h3: { color: '#C05621', fontWeight: 'bold', fontSize: 18.72 }, // darker orange
-            h4: { color: '#553C9A', fontWeight: 'bold', fontSize: 16 }, // darker purple
-            h5: { color: '#744210', fontWeight: 'bold', fontSize: 13.28 }, // darker brown
-            h6: { color: '#4A5568', fontWeight: 'bold', fontSize: 10.72 }, // medium gray
-          }}
+          renderStyles={htmlStyles}
         >
           {htmlComingFromServer}
         </NitroText>
@@ -510,7 +536,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#495057',
     lineHeight: 30,
-    padding:16,
+    padding: 16,
     borderRadius: 8,
     borderWidth: 1,
     borderColor: '#007bff',
@@ -629,7 +655,7 @@ const styles = StyleSheet.create({
   // Code syntax
   codeBlock: {
     fontSize: 14,
-    fontFamily: Platform.select({android:'monospace', ios: "ui-monospace"}),
+    fontFamily: Platform.select({ android: 'monospace', ios: 'ui-monospace' }),
     backgroundColor: '#1e1e1e',
     color: '#d4d4d4',
     padding: 16,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.4):
     - hermes-engine/Pre-built (= 0.81.4)
   - hermes-engine/Pre-built (0.81.4)
-  - NitroModules (0.29.6):
+  - NitroModules (0.29.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2643,7 +2643,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
-  NitroModules: 7d693306799405ca141ef5c24efc0936f20a09c0
+  NitroModules: 808eee1dfaf75b2c5a63ea3608cb651cc7d13687
   NitroText: c95604214333634a6a083ac7211b238686dbd628
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c0ed3249a97243002615517dff789bf4666cf585

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-safe-area-context": "^5.5.2",
-    "react-native-nitro-modules": "^0.29.6"
+    "react-native-nitro-modules": "^0.29.8"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/ios/NitroTextView.swift
+++ b/ios/NitroTextView.swift
@@ -46,7 +46,7 @@ final class NitroTextView: UITextView {
         backgroundColor = .clear
         textContainerInset = .zero
         textContainer.lineFragmentPadding = 0
-        layoutManager.usesFontLeading = true
+        layoutManager.usesFontLeading = false
         textColor = .black
         contentInset = .zero
         clipsToBounds = true

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotext/views/HybridNitroTextManager.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotext/views/HybridNitroTextManager.kt
@@ -17,7 +17,7 @@ import com.nitrotext.*
 /**
  * Represents the React Native `ViewManager` for the "NitroText" Nitro HybridView.
  */
-class HybridNitroTextManager: SimpleViewManager<View>() {
+open class HybridNitroTextManager: SimpleViewManager<View>() {
   private val views = hashMapOf<View, HybridNitroText>()
 
   override fun getName(): String {

--- a/nitrogen/generated/ios/NitroText-Swift-Cxx-Bridge.cpp
+++ b/nitrogen/generated/ios/NitroText-Swift-Cxx-Bridge.cpp
@@ -14,7 +14,7 @@
 namespace margelo::nitro::nitrotext::bridge::swift {
 
   // pragma MARK: std::function<void(const TextLayoutEvent& /* layout */)>
-  Func_void_TextLayoutEvent create_Func_void_TextLayoutEvent(void* _Nonnull swiftClosureWrapper) noexcept {
+  Func_void_TextLayoutEvent create_Func_void_TextLayoutEvent(void* NON_NULL swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroText::Func_void_TextLayoutEvent::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const TextLayoutEvent& layout) mutable -> void {
       swiftClosure.call(layout);
@@ -22,7 +22,7 @@ namespace margelo::nitro::nitrotext::bridge::swift {
   }
   
   // pragma MARK: std::function<void()>
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept {
+  Func_void create_Func_void(void* NON_NULL swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroText::Func_void::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> void {
       swiftClosure.call();
@@ -30,11 +30,11 @@ namespace margelo::nitro::nitrotext::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridNitroTextSpec>
-  std::shared_ptr<HybridNitroTextSpec> create_std__shared_ptr_HybridNitroTextSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
+  std::shared_ptr<HybridNitroTextSpec> create_std__shared_ptr_HybridNitroTextSpec_(void* NON_NULL swiftUnsafePointer) noexcept {
     NitroText::HybridNitroTextSpec_cxx swiftPart = NitroText::HybridNitroTextSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::nitrotext::HybridNitroTextSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridNitroTextSpec_(std__shared_ptr_HybridNitroTextSpec_ cppType) noexcept {
+  void* NON_NULL get_std__shared_ptr_HybridNitroTextSpec_(std__shared_ptr_HybridNitroTextSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::nitrotext::HybridNitroTextSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::nitrotext::HybridNitroTextSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {

--- a/nitrogen/generated/ios/NitroText-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroText-Swift-Cxx-Bridge.hpp
@@ -62,6 +62,7 @@ namespace NitroText { class HybridNitroTextSpec_cxx; }
 #include "TextLayout.hpp"
 #include "TextLayoutEvent.hpp"
 #include "TextTransform.hpp"
+#include <NitroModules/FastVectorCopy.hpp>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -199,10 +200,11 @@ namespace margelo::nitro::nitrotext::bridge::swift {
    * Specialized version of `std::vector<Fragment>`.
    */
   using std__vector_Fragment_ = std::vector<Fragment>;
-  inline std::vector<Fragment> create_std__vector_Fragment_(size_t size) noexcept {
-    std::vector<Fragment> vector;
-    vector.reserve(size);
-    return vector;
+  inline std::vector<Fragment> copy_std__vector_Fragment_(const Fragment* CONTIGUOUS_MEMORY NON_NULL data, size_t size) noexcept {
+    return margelo::nitro::FastVectorCopy<Fragment>(data, size);
+  }
+  inline const Fragment* CONTIGUOUS_MEMORY NON_NULL get_data_std__vector_Fragment_(const std::vector<Fragment>& vector) noexcept {
+    return vector.data();
   }
   
   // pragma MARK: std::optional<std::vector<Fragment>>
@@ -240,10 +242,11 @@ namespace margelo::nitro::nitrotext::bridge::swift {
    * Specialized version of `std::vector<RichTextStyleRule>`.
    */
   using std__vector_RichTextStyleRule_ = std::vector<RichTextStyleRule>;
-  inline std::vector<RichTextStyleRule> create_std__vector_RichTextStyleRule_(size_t size) noexcept {
-    std::vector<RichTextStyleRule> vector;
-    vector.reserve(size);
-    return vector;
+  inline std::vector<RichTextStyleRule> copy_std__vector_RichTextStyleRule_(const RichTextStyleRule* CONTIGUOUS_MEMORY NON_NULL data, size_t size) noexcept {
+    return margelo::nitro::FastVectorCopy<RichTextStyleRule>(data, size);
+  }
+  inline const RichTextStyleRule* CONTIGUOUS_MEMORY NON_NULL get_data_std__vector_RichTextStyleRule_(const std::vector<RichTextStyleRule>& vector) noexcept {
+    return vector.data();
   }
   
   // pragma MARK: std::optional<std::vector<RichTextStyleRule>>
@@ -326,10 +329,11 @@ namespace margelo::nitro::nitrotext::bridge::swift {
    * Specialized version of `std::vector<TextLayout>`.
    */
   using std__vector_TextLayout_ = std::vector<TextLayout>;
-  inline std::vector<TextLayout> create_std__vector_TextLayout_(size_t size) noexcept {
-    std::vector<TextLayout> vector;
-    vector.reserve(size);
-    return vector;
+  inline std::vector<TextLayout> copy_std__vector_TextLayout_(const TextLayout* CONTIGUOUS_MEMORY NON_NULL data, size_t size) noexcept {
+    return margelo::nitro::FastVectorCopy<TextLayout>(data, size);
+  }
+  inline const TextLayout* CONTIGUOUS_MEMORY NON_NULL get_data_std__vector_TextLayout_(const std::vector<TextLayout>& vector) noexcept {
+    return vector.data();
   }
   
   // pragma MARK: std::function<void(const TextLayoutEvent& /* layout */)>
@@ -349,7 +353,7 @@ namespace margelo::nitro::nitrotext::bridge::swift {
   private:
     std::unique_ptr<std::function<void(const TextLayoutEvent& /* layout */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_TextLayoutEvent create_Func_void_TextLayoutEvent(void* _Nonnull swiftClosureWrapper) noexcept;
+  Func_void_TextLayoutEvent create_Func_void_TextLayoutEvent(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_TextLayoutEvent_Wrapper wrap_Func_void_TextLayoutEvent(Func_void_TextLayoutEvent value) noexcept {
     return Func_void_TextLayoutEvent_Wrapper(std::move(value));
   }
@@ -386,7 +390,7 @@ namespace margelo::nitro::nitrotext::bridge::swift {
   private:
     std::unique_ptr<std::function<void()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept;
+  Func_void create_Func_void(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_Wrapper wrap_Func_void(Func_void value) noexcept {
     return Func_void_Wrapper(std::move(value));
   }
@@ -411,8 +415,8 @@ namespace margelo::nitro::nitrotext::bridge::swift {
    * Specialized version of `std::shared_ptr<HybridNitroTextSpec>`.
    */
   using std__shared_ptr_HybridNitroTextSpec_ = std::shared_ptr<HybridNitroTextSpec>;
-  std::shared_ptr<HybridNitroTextSpec> create_std__shared_ptr_HybridNitroTextSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
-  void* _Nonnull get_std__shared_ptr_HybridNitroTextSpec_(std__shared_ptr_HybridNitroTextSpec_ cppType) noexcept;
+  std::shared_ptr<HybridNitroTextSpec> create_std__shared_ptr_HybridNitroTextSpec_(void* NON_NULL swiftUnsafePointer) noexcept;
+  void* NON_NULL get_std__shared_ptr_HybridNitroTextSpec_(std__shared_ptr_HybridNitroTextSpec_ cppType) noexcept;
   
   // pragma MARK: std::weak_ptr<HybridNitroTextSpec>
   using std__weak_ptr_HybridNitroTextSpec_ = std::weak_ptr<HybridNitroTextSpec>;

--- a/nitrogen/generated/ios/swift/HybridNitroTextSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextSpec_cxx.swift
@@ -111,13 +111,9 @@ open class HybridNitroTextSpec_cxx {
     get {
       return { () -> bridge.std__optional_std__vector_Fragment__ in
         if let __unwrappedValue = self.__implementation.fragments {
-          return bridge.create_std__optional_std__vector_Fragment__({ () -> bridge.std__vector_Fragment_ in
-            var __vector = bridge.create_std__vector_Fragment_(__unwrappedValue.count)
-            for __item in __unwrappedValue {
-              __vector.push_back(__item)
-            }
-            return __vector
-          }())
+          return bridge.create_std__optional_std__vector_Fragment__(__unwrappedValue.withUnsafeBufferPointer { __pointer -> bridge.std__vector_Fragment_ in
+            return bridge.copy_std__vector_Fragment_(__pointer.baseAddress!, __unwrappedValue.count)
+          })
         } else {
           return .init()
         }
@@ -128,7 +124,11 @@ open class HybridNitroTextSpec_cxx {
       self.__implementation.fragments = { () -> [Fragment]? in
         if bridge.has_value_std__optional_std__vector_Fragment__(newValue) {
           let __unwrapped = bridge.get_std__optional_std__vector_Fragment__(newValue)
-          return __unwrapped.map({ __item in __item })
+          return { () -> [Fragment] in
+            let __data = bridge.get_data_std__vector_Fragment_(__unwrapped)
+            let __size = __unwrapped.size()
+            return Array(UnsafeBufferPointer(start: __data, count: __size))
+          }()
         } else {
           return nil
         }
@@ -158,13 +158,9 @@ open class HybridNitroTextSpec_cxx {
     get {
       return { () -> bridge.std__optional_std__vector_RichTextStyleRule__ in
         if let __unwrappedValue = self.__implementation.richTextStyleRules {
-          return bridge.create_std__optional_std__vector_RichTextStyleRule__({ () -> bridge.std__vector_RichTextStyleRule_ in
-            var __vector = bridge.create_std__vector_RichTextStyleRule_(__unwrappedValue.count)
-            for __item in __unwrappedValue {
-              __vector.push_back(__item)
-            }
-            return __vector
-          }())
+          return bridge.create_std__optional_std__vector_RichTextStyleRule__(__unwrappedValue.withUnsafeBufferPointer { __pointer -> bridge.std__vector_RichTextStyleRule_ in
+            return bridge.copy_std__vector_RichTextStyleRule_(__pointer.baseAddress!, __unwrappedValue.count)
+          })
         } else {
           return .init()
         }
@@ -175,7 +171,11 @@ open class HybridNitroTextSpec_cxx {
       self.__implementation.richTextStyleRules = { () -> [RichTextStyleRule]? in
         if bridge.has_value_std__optional_std__vector_RichTextStyleRule__(newValue) {
           let __unwrapped = bridge.get_std__optional_std__vector_RichTextStyleRule__(newValue)
-          return __unwrapped.map({ __item in __item })
+          return { () -> [RichTextStyleRule] in
+            let __data = bridge.get_data_std__vector_RichTextStyleRule_(__unwrapped)
+            let __size = __unwrapped.size()
+            return Array(UnsafeBufferPointer(start: __data, count: __size))
+          }()
         } else {
           return nil
         }

--- a/nitrogen/generated/ios/swift/TextLayoutEvent.swift
+++ b/nitrogen/generated/ios/swift/TextLayoutEvent.swift
@@ -19,29 +19,25 @@ public extension TextLayoutEvent {
    * Create a new instance of `TextLayoutEvent`.
    */
   init(lines: [TextLayout]) {
-    self.init({ () -> bridge.std__vector_TextLayout_ in
-      var __vector = bridge.create_std__vector_TextLayout_(lines.count)
-      for __item in lines {
-        __vector.push_back(__item)
-      }
-      return __vector
-    }())
+    self.init(lines.withUnsafeBufferPointer { __pointer -> bridge.std__vector_TextLayout_ in
+      return bridge.copy_std__vector_TextLayout_(__pointer.baseAddress!, lines.count)
+    })
   }
 
   var lines: [TextLayout] {
     @inline(__always)
     get {
-      return self.__lines.map({ __item in __item })
+      return { () -> [TextLayout] in
+        let __data = bridge.get_data_std__vector_TextLayout_(self.__lines)
+        let __size = self.__lines.size()
+        return Array(UnsafeBufferPointer(start: __data, count: __size))
+      }()
     }
     @inline(__always)
     set {
-      self.__lines = { () -> bridge.std__vector_TextLayout_ in
-        var __vector = bridge.create_std__vector_TextLayout_(newValue.count)
-        for __item in newValue {
-          __vector.push_back(__item)
-        }
-        return __vector
-      }()
+      self.__lines = newValue.withUnsafeBufferPointer { __pointer -> bridge.std__vector_TextLayout_ in
+        return bridge.copy_std__vector_TextLayout_(__pointer.baseAddress!, newValue.count)
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "@types/jest": "^29.5.12",
     "@types/react": "19.1.0",
     "conventional-changelog-conventionalcommits": "^9.1.0",
-    "nitrogen": "^0.29.6",
+    "nitrogen": "^0.29.8",
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-builder-bob": "^0.37.0",
-    "react-native-nitro-modules": "^0.29.6",
+    "react-native-nitro-modules": "^0.29.8",
     "semantic-release": "^24.2.8",
     "typescript": "^5.8.3"
   },


### PR DESCRIPTION
# Pull Request
chore: bum up nitro 0.29.8

## Description
- Bump `nitrogen` and `react-native-nitro-modules` versions to `0.29.8` in `package.json`, `example/package.json`, and `bun.lock`.
- Update `Podfile.lock` to reflect the new `NitroModules` version.
- Modify Kotlin and Swift bridge files to enhance type safety with `NON_NULL` annotations.
- Refactor vector handling in Swift to utilize `FastVectorCopy` for better performance.

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Testing

- [ ] Tested on iOS
- [ ] Tested on Android
- [ ] Added/updated tests

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)

## Additional Notes

Any additional information for reviewers.
